### PR TITLE
Added nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ google-tasks-cli
 gtasks
 gtasks.exe
 bin/*
-
+result
 dist/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,30 @@ or you can download the binary:
 3. Append the absolute path (use `pwd`) of the folder to `PATH`
 4. Execute `gtasks` from anywhere
 
+## Instructions to Run on [Nix](https://nixos.org)
+
+(make sure `nix` is installed in your system and nix-command, flakes enabled)
+
+```bash
+nix run "github:BRO3886/gtasks"
+```
+
+Installing in nix config
+
+```nix
+  inputs = {
+
+    gtasks = {
+      url = "github:BRO3886/gtasks";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+```
+
+```nix
+  environment.systemPackages = [ inputs.gtasks.packages.${pkgs.system}.default ];
+```
+
 ## Instructions to Run and Build from Source:
 
 - Pre-requisites

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,19 @@
+{ lib, buildGoModule }:
+
+buildGoModule {
+  pname = "gtasks";
+  version = "latest"; # Or specify a particular version
+
+  # Fetching the source from GitHub repository
+  src = ./.;
+
+  vendorHash = "sha256-eZfgB91pTORpwO5uTMCiVxRP6BlVwQDMzpfScfRUkWI=";
+  # Optional, add meta information
+  meta = with lib; {
+    description = "A command-line task manager written in Go";
+    homepage = "https://github.com/BRO3886/gtasks";
+    license = licenses.mit;
+    maintainers = with maintainers; [ niksingh710 ];
+  };
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems =
+        [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { pkgs, ... }: {
+        packages.default = pkgs.callPackage ./default.nix {};
+      };
+    };
+}


### PR DESCRIPTION
This adds the support for NixOs/nix package manager

I have seen the last update to the package was 2yrs ago.

Any one can add the option for authentiation via `--client-id` and `--client-secret` command line args.?

as right now it looks for `config.json` in the installed binary location and that is not accessible in nixos.