### PR TITLE
docs: make "`go install` not working" a little clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Refer to the [docs website](https://gtasks.sidv.dev) to read about available com
 
 ## Instructions to install using go install
 
-> Not working yet. Will be fixed soon.
+> [!WARNING]
+> Installing via `go install` is currently not working. Will be fixed soon.
 
 ```bash
 go install github.com/BRO3886/gtasks@latest


### PR DESCRIPTION
Thanks for this - via https://github.com/BRO3886/gtasks/issues/26 and https://github.com/BRO3886/gtasks/issues/28 I'd missed this note - this may make it slightly clearer to folks.