### PR TITLE
look for environment variable to specify default tasks list

### DIFF
--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -782,16 +782,21 @@ func getTaskLists(srv *tasks.Service) tasks.TaskList {
 
 	index := -1
 
-	if taskListFlag != "" {
+	effectiveList := taskListFlag
+	if effectiveList == "" {
+		effectiveList = os.Getenv("GTASKS_DEFAULT_TASKLIST")
+	}
+
+	if effectiveList != "" {
 
 		var titles []string
 		for _, tasklist := range list {
 			titles = append(titles, tasklist.Title)
 		}
 
-		index = sort.SearchStrings(titles, taskListFlag)
+		index = sort.SearchStrings(titles, effectiveList)
 
-		if !(index >= 0 && index < len(list) && list[index].Title == taskListFlag) {
+		if !(index >= 0 && index < len(list) && list[index].Title == effectiveList) {
 			utils.ErrorP("%s\n", "incorrect task-list name")
 		}
 


### PR DESCRIPTION
Instead of providing a tasks list with the `-l` command line switch, gtasks now looks for the `GTASKS_DEFAULT_TASKLIST` environment variable.

The `-l` flag always takes precedence over the environment variable and the environment variable takes precedence over the interactive prompt.

Addresses issue #36, at least in part -- being able to specify a default tasks list in a proper configuration file would be nice, too.