### PR TITLE
skip prompt to select a task list when there is only one

### DIFF
--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -795,6 +795,8 @@ func getTaskLists(srv *tasks.Service) tasks.TaskList {
 			utils.ErrorP("%s\n", "incorrect task-list name")
 		}
 
+	} else if len(list) == 1 {
+		index = 0
 	} else {
 		utils.Print("Choose a Tasklist:")
 		var l []string


### PR DESCRIPTION
If no task list is otherwise provided, commands like `gtasks tasks view` will prompt the user to select a task list -- even if there is only one.

Now, when gtasks has not otherwise been told to use a certain task list, and there is only one list found, it just uses that list.

Addresses #36, in part -- this PR is independent of the already-attached PR on that issue.