### PR TITLE
Add support for configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,18 +102,41 @@ To use GTasks, you need to set up Google OAuth2 credentials:
      - `http://localhost:9090/callback`
      - `http://localhost:9091/callback`
 
-5. Set environment variables:
+5. Supply credentials via environment variables:
 
 ```bash
 export GTASKS_CLIENT_ID="your-client-id.apps.googleusercontent.com"
 export GTASKS_CLIENT_SECRET="your-client-secret"
 ```
 
-Or create a `.env` file (for building from source).
+Or add them to `~/.config/gtasks/config.toml` (persistent, no shell profile changes needed):
 
-### Token Storage
+```toml
+[credentials]
+client_id     = "your-client-id.apps.googleusercontent.com"
+client_secret = "your-client-secret"
+```
 
-GTasks stores authentication tokens in `~/.gtasks/token.json`. This directory is created automatically on first login.
+Or create a `.env` file (for building from source only).
+
+### Token Storage and Configuration
+
+GTasks stores authentication tokens and the optional config file in the same directory.
+Discovery order (first existing directory wins):
+
+1. `$XDG_CONFIG_HOME/gtasks/` — XDG standard path; `XDG_CONFIG_HOME` defaults to `~/.config`
+2. `~/.gtasks/` — legacy path, used automatically when that directory already exists
+
+New installations use `~/.config/gtasks/` by default.
+
+**Files stored:**
+
+| File | Purpose |
+|------|---------|
+| `token.json` | OAuth2 token (created on `gtasks login`) |
+| `config.toml` | Optional configuration file (created manually) |
+
+See the [Configuration docs](https://gtasks.sidv.dev/docs/configuration/) for the full config file reference.
 
 - Usage
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/BRO3886/gtasks/internal/config"
 	"github.com/BRO3886/gtasks/internal/utils"
 	"github.com/spf13/cobra"
 
@@ -44,26 +45,26 @@ func init() {
 	viper.SetDefault("license", "apache")
 }
 
-// initConfig reads in config file and ENV variables if set.
+// initConfig loads the gtasks config file and reads environment variables.
 func initConfig() {
+	// Load config.toml from the XDG/gtasks config directory.
+	config.LoadAppConfig()
+
 	if cfgFile != "" {
-		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// Find home directory.
 		home, err := homedir.Dir()
 		if err != nil {
 			utils.ErrorP("%v", err)
 		}
-
-		// Search config in home directory with name ".google-tasks-cli" (without extension).
 		viper.AddConfigPath(home)
 		viper.SetConfigName(".google-tasks-cli")
 	}
 
-	viper.AutomaticEnv() // read in environment variables that match
+	viper.AutomaticEnv()
 
-	// If a config file is found, read it in.
+	// Suppress "config file not found" — the legacy viper config (.google-tasks-cli) is
+	// not used; gtasks reads its own config.toml via config.LoadAppConfig() above.
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/BRO3886/gtasks/api"
+	"github.com/BRO3886/gtasks/internal/config"
 	"github.com/BRO3886/gtasks/internal/utils"
 	"github.com/araddon/dateparse"
 	"github.com/fatih/color"
@@ -782,19 +783,26 @@ func getTaskLists(srv *tasks.Service) tasks.TaskList {
 
 	index := -1
 
-	if taskListFlag != "" {
+	// Resolution order: -l flag > GTASKS_DEFAULT_TASKLIST env var > config file default_task_list
+	effectiveList := taskListFlag
+	if effectiveList == "" {
+		effectiveList = os.Getenv("GTASKS_DEFAULT_TASKLIST")
+	}
+	if effectiveList == "" {
+		effectiveList = config.GetDefaultTaskList()
+	}
 
+	if effectiveList != "" {
 		var titles []string
 		for _, tasklist := range list {
 			titles = append(titles, tasklist.Title)
 		}
 
-		index = sort.SearchStrings(titles, taskListFlag)
+		index = sort.SearchStrings(titles, effectiveList)
 
-		if !(index >= 0 && index < len(list) && list[index].Title == taskListFlag) {
-			utils.ErrorP("%s\n", "incorrect task-list name")
+		if !(index >= 0 && index < len(list) && list[index].Title == effectiveList) {
+			utils.ErrorP("%s '%s'\n", "incorrect task-list name", effectiveList)
 		}
-
 	} else {
 		utils.Print("Choose a Tasklist:")
 		var l []string

--- a/docs/content/docs/configuration/index.md
+++ b/docs/content/docs/configuration/index.md
@@ -1,0 +1,128 @@
+---
+title: "Configuration"
+draft: false
+weight: 5
+summary: Configure gtasks with a config file, environment variables, or build-time flags
+---
+
+GTasks supports configuration through a TOML file, environment variables, and CLI flags.
+Each layer can override the one below it:
+
+```
+CLI flag  >  environment variable  >  config file  >  build-time default
+```
+
+## Config file location
+
+GTasks follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+The config file is named **`config.toml`** and is found by checking these directories in order:
+
+| Priority | Path | Notes |
+|----------|------|-------|
+| 1 | `$XDG_CONFIG_HOME/gtasks/config.toml` | XDG standard path; `XDG_CONFIG_HOME` defaults to `~/.config` |
+| 2 | `~/.gtasks/config.toml` | Legacy path; used automatically when the `~/.gtasks/` directory already exists |
+
+New installations always use the XDG path (`~/.config/gtasks/` by default). Existing
+installations that already have a `~/.gtasks/` directory continue using it without any
+changes. To migrate, move the directory and set `XDG_CONFIG_HOME` if needed.
+
+Authentication tokens (`token.json`) are stored alongside `config.toml` in the same directory.
+
+## Creating the config file
+
+Create the file manually:
+
+```bash
+mkdir -p ~/.config/gtasks
+touch ~/.config/gtasks/config.toml
+```
+
+## Config file format
+
+The file uses [TOML](https://toml.io) syntax. All keys are optional — omit any section
+or key you do not need.
+
+```toml
+# GTasks configuration file
+# Location: $XDG_CONFIG_HOME/gtasks/config.toml  (usually ~/.config/gtasks/config.toml)
+#           ~/.gtasks/config.toml                 (legacy path, used when ~/.gtasks/ exists)
+
+[credentials]
+# OAuth2 client ID for the Google Tasks API.
+# Only required when you are building gtasks from source with your own Google Cloud project.
+# Overridden by: GTASKS_CLIENT_ID environment variable.
+# client_id = "your-client-id.apps.googleusercontent.com"
+
+# OAuth2 client secret for the Google Tasks API.
+# Only required when you are building gtasks from source with your own Google Cloud project.
+# Overridden by: GTASKS_CLIENT_SECRET environment variable.
+# client_secret = "your-client-secret"
+
+[tasks]
+# Default task list to use when the -l / --tasklist flag is not provided.
+# When set, gtasks skips the interactive task list prompt.
+# Overridden by: GTASKS_DEFAULT_TASKLIST environment variable, then the -l flag.
+# default_task_list = "My Tasks"
+```
+
+## Settings reference
+
+### `[credentials]`
+
+These settings are needed only when building gtasks from source with your own Google Cloud
+project. Released binaries have credentials embedded at build time.
+
+| Key | Type | Env var override | Description |
+|-----|------|-----------------|-------------|
+| `client_id` | string | `GTASKS_CLIENT_ID` | Google OAuth2 client ID |
+| `client_secret` | string | `GTASKS_CLIENT_SECRET` | Google OAuth2 client secret |
+
+### `[tasks]`
+
+| Key | Type | Env var override | CLI flag override | Description |
+|-----|------|-----------------|-------------------|-------------|
+| `default_task_list` | string | `GTASKS_DEFAULT_TASKLIST` | `-l` / `--tasklist` | Task list selected automatically when no flag is given |
+
+## Examples
+
+### Set a default task list
+
+To always operate on "Work" without typing `-l "Work"` every time:
+
+```toml
+[tasks]
+default_task_list = "Work"
+```
+
+Then:
+
+```bash
+# No prompt, uses "Work" automatically
+gtasks tasks view
+gtasks tasks add -t "Finish report"
+
+# Override for a single command with the flag
+gtasks tasks view -l "Personal"
+```
+
+### Supply credentials for a custom build
+
+```toml
+[credentials]
+client_id     = "123456789-abc.apps.googleusercontent.com"
+client_secret = "GOCSPX-xxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+This is equivalent to setting the `GTASKS_CLIENT_ID` and `GTASKS_CLIENT_SECRET` environment
+variables, but stored persistently in the config file.
+
+## Environment variables
+
+All settings in the config file can be overridden with environment variables:
+
+| Variable | Overrides |
+|----------|-----------|
+| `GTASKS_CLIENT_ID` | `credentials.client_id` |
+| `GTASKS_CLIENT_SECRET` | `credentials.client_secret` |
+| `GTASKS_DEFAULT_TASKLIST` | `tasks.default_task_list` |
+| `XDG_CONFIG_HOME` | Base directory for the config folder (XDG spec) |

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/pelletier/go-toml v1.9.4
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
 	golang.org/x/oauth2 v0.34.0
@@ -37,7 +38,6 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/rivo/uniseg v0.1.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -17,28 +17,41 @@ var ClientID = ""
 // Note: For Google OAuth2, even "public" desktop clients require a client secret
 var ClientSecret = ""
 
-// GetOAuth2Config creates OAuth2 configuration for Google Tasks API
+// GetOAuth2Config creates OAuth2 configuration for Google Tasks API.
+//
+// Credential resolution order (highest priority first):
+//  1. GTASKS_CLIENT_ID / GTASKS_CLIENT_SECRET environment variables
+//  2. credentials.client_id / credentials.client_secret in config.toml
+//  3. Client ID / secret embedded at build time via -ldflags
 func GetOAuth2Config() (*oauth2.Config, error) {
-	// Try environment variable first for client ID
+	// 1. Environment variable
 	clientID := os.Getenv("GTASKS_CLIENT_ID")
+	// 2. Config file
 	if clientID == "" {
-		// Fall back to build-time injected client ID
+		clientID = appCfg.Credentials.ClientID
+	}
+	// 3. Build-time injected value
+	if clientID == "" {
 		clientID = ClientID
 	}
 
 	if clientID == "" {
-		return nil, fmt.Errorf("no client ID found. Set GTASKS_CLIENT_ID environment variable or rebuild with client ID")
+		return nil, fmt.Errorf("no client ID found. Set GTASKS_CLIENT_ID environment variable, add client_id under [credentials] in config.toml, or rebuild with client ID")
 	}
 
-	// Try environment variable first for client secret
+	// 1. Environment variable
 	clientSecret := os.Getenv("GTASKS_CLIENT_SECRET")
+	// 2. Config file
 	if clientSecret == "" {
-		// Fall back to build-time injected client secret
+		clientSecret = appCfg.Credentials.ClientSecret
+	}
+	// 3. Build-time injected value
+	if clientSecret == "" {
 		clientSecret = ClientSecret
 	}
 
 	if clientSecret == "" {
-		return nil, fmt.Errorf("no client secret found. Set GTASKS_CLIENT_SECRET environment variable or rebuild with client secret")
+		return nil, fmt.Errorf("no client secret found. Set GTASKS_CLIENT_SECRET environment variable, add client_secret under [credentials] in config.toml, or rebuild with client secret")
 	}
 
 	config := &oauth2.Config{

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/BRO3886/gtasks/internal/utils"
+	"github.com/pelletier/go-toml"
+)
+
+// AppConfig holds settings loaded from the gtasks configuration file (config.toml).
+//
+// The file is looked up in GetInstallLocation() — typically
+// $XDG_CONFIG_HOME/gtasks/config.toml (or ~/.gtasks/config.toml for legacy installs).
+//
+// Environment variables and CLI flags override values set here; see each field for details.
+type AppConfig struct {
+	// Credentials holds OAuth2 client credentials for the Google Tasks API.
+	// These are only needed when building or running gtasks with your own
+	// Google Cloud project; official releases have credentials embedded at build time.
+	Credentials struct {
+		// ClientID is the Google OAuth2 client ID.
+		// Overridden by the GTASKS_CLIENT_ID environment variable.
+		ClientID string `toml:"client_id"`
+
+		// ClientSecret is the Google OAuth2 client secret.
+		// Overridden by the GTASKS_CLIENT_SECRET environment variable.
+		ClientSecret string `toml:"client_secret"`
+	} `toml:"credentials"`
+
+	// Tasks holds preferences for task operations.
+	Tasks struct {
+		// DefaultTaskList is the task list name used when the -l flag is not provided.
+		// Overridden by the GTASKS_DEFAULT_TASKLIST environment variable, then by -l flag.
+		DefaultTaskList string `toml:"default_task_list"`
+	} `toml:"tasks"`
+}
+
+// appCfg is the package-level config loaded by LoadAppConfig.
+var appCfg AppConfig
+
+// LoadAppConfig reads config.toml from the gtasks configuration directory and stores
+// the result in the package-level appCfg variable. A missing config file is silently
+// ignored; a malformed file logs a warning and uses zero-value defaults.
+func LoadAppConfig() {
+	cfgPath := filepath.Join(GetInstallLocation(), "config.toml")
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			utils.Warn("Could not read config file %s: %v\n", cfgPath, err)
+		}
+		return
+	}
+
+	if err := toml.Unmarshal(data, &appCfg); err != nil {
+		utils.Warn("Could not parse config file %s: %v\n", cfgPath, err)
+	}
+}
+
+// GetAppConfig returns the loaded application configuration.
+func GetAppConfig() AppConfig {
+	return appCfg
+}
+
+// GetDefaultTaskList returns the default task list name from the config file,
+// or an empty string if none is set.
+func GetDefaultTaskList() string {
+	return appCfg.Tasks.DefaultTaskList
+}

--- a/internal/config/get_install_loc.go
+++ b/internal/config/get_install_loc.go
@@ -7,21 +7,73 @@ import (
 	"github.com/BRO3886/gtasks/internal/utils"
 )
 
-// GetInstallLocation returns the ~/.gtasks directory for storing config and tokens
+// GetInstallLocation returns the directory used for gtasks configuration and token storage.
+//
+// Discovery order (first existing directory wins):
+//  1. $XDG_CONFIG_HOME/gtasks/  (or ~/.config/gtasks/ when XDG_CONFIG_HOME is unset)
+//  2. ~/.gtasks/                 (legacy path, kept for backward compatibility)
+//
+// If neither directory exists, $XDG_CONFIG_HOME/gtasks/ is created for new installations.
+// The legacy path ~/.gtasks/ is never created for new installs; only existing installs continue
+// using it.
 func GetInstallLocation() string {
-	homeDir, err := os.UserHomeDir()
+	xdgDir := xdgConfigDir()
+	legacyDir := legacyConfigDir()
+
+	// Prefer XDG dir if it already exists
+	if xdgDir != "" {
+		if _, err := os.Stat(xdgDir); err == nil {
+			return xdgDir
+		}
+	}
+
+	// Fall back to legacy ~/.gtasks if it exists
+	if legacyDir != "" {
+		if _, err := os.Stat(legacyDir); err == nil {
+			return legacyDir
+		}
+	}
+
+	// Neither exists — create XDG dir for new installations
+	if xdgDir != "" {
+		if err := os.MkdirAll(xdgDir, 0755); err == nil {
+			return xdgDir
+		}
+		utils.ErrorP("Create XDG config directory %s: %s", xdgDir, "failed")
+	}
+
+	// Final fallback: create legacy dir
+	if legacyDir != "" {
+		if err := os.MkdirAll(legacyDir, 0755); err == nil {
+			return legacyDir
+		}
+		utils.ErrorP("Create config directory %s: %s", legacyDir, "failed")
+	}
+
+	return ".gtasks" // unreachable in practice
+}
+
+// xdgConfigDir returns $XDG_CONFIG_HOME/gtasks, or ~/.config/gtasks if XDG_CONFIG_HOME is
+// unset or empty (per XDG Base Directory Specification). Returns empty string if the home
+// directory cannot be determined.
+func xdgConfigDir() string {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		base = filepath.Join(home, ".config")
+	}
+	return filepath.Join(base, "gtasks")
+}
+
+// legacyConfigDir returns ~/.gtasks, or empty string if the home directory cannot be
+// determined.
+func legacyConfigDir() string {
+	home, err := os.UserHomeDir()
 	if err != nil {
-		utils.ErrorP("Get home directory: %s", err.Error())
-		return ".gtasks" // fallback to current directory
+		return ""
 	}
-	
-	configDir := filepath.Join(homeDir, ".gtasks")
-	
-	// Create directory if it doesn't exist
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		utils.ErrorP("Create config directory: %s", err.Error())
-		return homeDir // fallback to home directory
-	}
-	
-	return configDir
+	return filepath.Join(home, ".gtasks")
 }


### PR DESCRIPTION
gtasks now reads in configuration from config.toml in its configuration directory. Currently the client ID, secret, and default task list can be specified.

It now also follows the XDG desktop standard for the location of its configuration directory.

This also addresses, in part, issue #36.