### PR TITLE
Add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ gtasks skills uninstall --agent codex
 
 ## Installation
 
-**macOS / Linux (recommended):**
+### Homebrew
+
+```bash
+brew tap BRO3886/tap
+brew install gtasks
+```
+
+**macOS / Linux (install script):**
 
 ```bash
 curl -fsSL https://gtasks.sidv.dev/install | bash


### PR DESCRIPTION
A Homebrew tap (BRO3886/tap) has been set up for gtasks. This PR adds `brew tap` + `brew install` instructions to the README so users can install via Homebrew directly.

Homebrew is placed first in the Installation section as the easiest install path on macOS.
