### PR TITLE
Lengthen short meta descriptions flagged by Bing Webmaster

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "gtasks — Google Tasks CLI"
-description: "Manage Google Tasks from the terminal. View, add, complete, and delete tasks with one command."
+description: "gtasks is a fast Google Tasks CLI written in Go. View, add, complete, and delete tasks and task lists from your terminal, and let AI agents manage them too."
 keywords:
   - Google Tasks CLI
   - gtasks

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Documentation"
-description: "Complete documentation for gtasks — the Google Tasks CLI tool."
+description: "Complete documentation for gtasks, the Go-based Google Tasks CLI: installation, OAuth2 login, and commands to manage task lists and tasks from the terminal."
 weight: 1
 sitemap:
   priority: 0.9

--- a/docs/content/docs/login/index.md
+++ b/docs/content/docs/login/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Logging In"
-description: "Authenticate gtasks with your Google account using OAuth2. Token stored securely in system keyring."
+description: "Authenticate gtasks with your Google account over OAuth2. Set client credentials via environment variables or a config file; tokens stay in the system keyring."
 draft: false
 weight: 3
 sitemap:

--- a/docs/content/docs/tasklist commands/index.md
+++ b/docs/content/docs/tasklist commands/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Tasklist commands"
-description: "View, create, update, and delete Google Task lists from the terminal with gtasks."
+description: "Manage Google task lists from the terminal with gtasks: view, create, update, and delete tasklists, and see inline help for every tasklist command you can run."
 draft: false
 weight: 3
 sitemap:


### PR DESCRIPTION
Bing Webmaster flagged four gtasks.sidv.dev pages for meta descriptions below the recommended length. This rewrites each page's frontmatter `description` to a unique, page-specific summary of 150 to 160 characters.

Pages fixed (rendered length in built HTML):
- `/` — 156 chars
- `/docs/` — 156 chars
- `/docs/login/` — 159 chars
- `/docs/tasklist-commands/` — 159 chars

Verified by building the Hugo site (`hugo --gc`) and grepping the `<meta name="description">` tag in `docs/public/*`. Source-only change to markdown frontmatter; no template or config changes.
